### PR TITLE
Release: emergence-skeleton-v2 v2.1.12

### DIFF
--- a/.holo/branches/emergence-site/_skeleton-v2.toml
+++ b/.holo/branches/emergence-site/_skeleton-v2.toml
@@ -1,6 +1,6 @@
 [holomapping]
 files = [
     "*/**",
-    ".github/"
+    "!.github/"
 ]
 after = "skeleton-v1"


### PR DESCRIPTION
- fix: exclude rather than include .github/ tree