### PR TITLE
 Release: emergence-skeleton-v2 v2.4.0

### DIFF
--- a/.holo/sources/skeleton-v1.toml
+++ b/.holo/sources/skeleton-v1.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/emergence-skeleton.git"
-ref = "refs/tags/v1.11.3"
+ref = "refs/tags/v1.12.0"
 
 [holosource.project]
 holobranch = "emergence-skeleton"

--- a/php-config/Site.config.d/skip-sessions.php
+++ b/php-config/Site.config.d/skip-sessions.php
@@ -1,5 +1,5 @@
 <?php
 
 // these resolved paths will skip initializing a user session
-Site::$skipSessionPaths[] = 'thumbnail.php';
-Site::$skipSessionPaths[] = 'min.php';
+Site::$skipSessionPaths[] = 'thumbnail/';
+Site::$skipSessionPaths[] = 'min/';


### PR DESCRIPTION
- fix: use path prefix for Site::$skipSessionPaths
- chore: bump skeleton-v1 version to v1.12.0